### PR TITLE
Set resolver version to "2"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "cspice",
     "cspice-sys"


### PR DESCRIPTION
This suppresses warnings like:

warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`